### PR TITLE
Add interactive mission dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ The `ORE/osint` module provides basic automation for scraping news, monitoring s
 Use the generated `osint_map.html` to view collected intel on an interactive map.
 
 See `ORE/osint/README.md` for details.
+
+The `ore_webapp` directory provides a local FastAPI web application. It now includes an interactive dashboard with map overlays and time series charts summarizing mission data. Charts can be exported directly from the browser.

--- a/ore_webapp/README.md
+++ b/ore_webapp/README.md
@@ -6,7 +6,7 @@ This directory contains a basic scaffold for a secure, locally hostable web appl
 
 - **User Authentication** with hashed passwords and token-based session management.
 - **Encrypted File Storage** using symmetric encryption (Fernet).
-- **Dashboard** showing mission status from stored data.
+- **Dashboard** visualizing mission data with map overlays and time series charts. Charts can be exported to images or PDFs.
 - **Modular Apps** so new functionality can be added easily.
 
 All data is stored locally in SQLite and encrypted files remain offline. The app can be extended to integrate optional APIs for mapping or OSINT if needed.

--- a/ore_webapp/backend/app/routers/dashboard.py
+++ b/ore_webapp/backend/app/routers/dashboard.py
@@ -1,5 +1,10 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+from pathlib import Path
+import json
+import sqlite3
+from collections import Counter
+from datetime import datetime
 
 from ..database import get_db
 from ..models import User, StoredFile
@@ -12,3 +17,57 @@ def get_dashboard(db: Session = Depends(get_db)):
     users = db.query(User).count()
     files = db.query(StoredFile).count()
     return {"users": users, "files": files}
+
+
+@router.get("/mission-data")
+def mission_data():
+    root = Path(__file__).resolve().parents[4]
+    contacts_file = root / "contacts_data" / "contacts.json"
+    osint_db = root / "ORE" / "osint" / "ore_osint.db"
+
+    data = {
+        "map": [],
+        "time_series": [],
+        "active_contacts": 0,
+        "last_report": None,
+        "open_incidents": 0,
+    }
+
+    if contacts_file.exists():
+        try:
+            with open(contacts_file, "r", encoding="utf-8") as f:
+                contacts = json.load(f).get("contacts", [])
+                data["active_contacts"] = len(contacts)
+        except Exception:
+            pass
+
+    if osint_db.exists():
+        try:
+            conn = sqlite3.connect(osint_db)
+            cur = conn.execute(
+                "SELECT timestamp, latitude, longitude, title FROM intel"
+            )
+            rows = cur.fetchall()
+            data["open_incidents"] = len(rows)
+            last = None
+            counter = Counter()
+            for ts, lat, lon, title in rows:
+                if lat is not None and lon is not None:
+                    data["map"].append({"lat": lat, "lon": lon, "title": title})
+                if ts:
+                    try:
+                        dt = datetime.fromisoformat(ts)
+                    except ValueError:
+                        try:
+                            dt = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+                        except Exception:
+                            continue
+                    counter[dt.date().isoformat()] += 1
+                    if not last or dt > last:
+                        last = dt
+            data["time_series"] = sorted(counter.items())
+            data["last_report"] = last.isoformat() if last else None
+        finally:
+            conn.close()
+
+    return data

--- a/ore_webapp/frontend/dashboard.html
+++ b/ore_webapp/frontend/dashboard.html
@@ -3,19 +3,22 @@
 <head>
   <meta charset="utf-8" />
   <title>ORE Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
   <h1>Mission Dashboard</h1>
   <div id="stats"></div>
-  <script>
-    async function loadStats() {
-      const res = await fetch('/dashboard/');
-      if(res.ok) {
-        const data = await res.json();
-        document.getElementById('stats').innerText = `Users: ${data.users} Files: ${data.files}`;
-      }
-    }
-    loadStats();
-  </script>
+  <div id="map" style="height: 400px; margin-top: 1em;"></div>
+  <canvas id="chart" style="max-width: 100%; margin-top: 1em;"></canvas>
+  <div style="margin-top: 1em;">
+    <button id="export-img">Export Chart Image</button>
+    <button id="export-pdf">Export Chart PDF</button>
+  </div>
+  <script src="dashboard.js"></script>
 </body>
 </html>

--- a/ore_webapp/frontend/dashboard.js
+++ b/ore_webapp/frontend/dashboard.js
@@ -1,0 +1,56 @@
+async function loadData() {
+  const res = await fetch('/dashboard/mission-data');
+  if (!res.ok) return;
+  const data = await res.json();
+
+  // Quick stats
+  const stats = document.getElementById('stats');
+  stats.innerText = `Active contacts: ${data.active_contacts} | Last report: ${data.last_report || 'N/A'} | Open incidents: ${data.open_incidents}`;
+
+  // Map overlays
+  const map = L.map('map').setView([36.27, 43.38], 8);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+  (data.map || []).forEach(p => {
+    L.marker([p.lat, p.lon]).addTo(map).bindPopup(p.title);
+  });
+
+  // Time series chart
+  const labels = data.time_series.map(i => i[0]);
+  const counts = data.time_series.map(i => i[1]);
+  const ctx = document.getElementById('chart').getContext('2d');
+  window.chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [{ label: 'Incidents', data: counts, borderColor: 'red' }]
+    },
+    options: { responsive: true }
+  });
+}
+
+function exportChartImage() {
+  html2canvas(document.getElementById('chart')).then(canvas => {
+    const link = document.createElement('a');
+    link.download = 'chart.png';
+    link.href = canvas.toDataURL();
+    link.click();
+  });
+}
+
+function exportChartPDF() {
+  html2canvas(document.getElementById('chart')).then(canvas => {
+    const imgData = canvas.toDataURL('image/png');
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF();
+    pdf.addImage(imgData, 'PNG', 10, 10, 180, 100);
+    pdf.save('chart.pdf');
+  });
+}
+
+document.getElementById('export-img').addEventListener('click', exportChartImage);
+document.getElementById('export-pdf').addEventListener('click', exportChartPDF);
+
+loadData();
+


### PR DESCRIPTION
## Summary
- enrich dashboard backend with mission-data endpoint
- create interactive frontend dashboard with map and charts
- support exporting chart as image or PDF
- document new dashboard capability

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840a0315af48322a5350542bd5c053f