### PR TITLE
Add mission task board

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ The `ORE/osint` module provides basic automation for scraping news, monitoring s
 Use the generated `osint_map.html` to view collected intel on an interactive map.
 
 See `ORE/osint/README.md` for details.
+
+## Mission Task Board
+
+The web application now includes endpoints and a simple UI for managing mission
+tasks. Tasks can be created with fields for mission phase, urgency, location and
+the responsible user. Status updates and assignments allow the app to act as a
+basic Kanban board. Visit `tasks.html` after starting the server to add or view
+tasks.
+
+Daily or weekly status reports can be retrieved at `/tasks/reports/daily` or
+`/tasks/reports/weekly`.

--- a/ore_webapp/backend/app/main.py
+++ b/ore_webapp/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
 from .database import Base, engine
-from .routers import auth, dashboard, files
+from .routers import auth, dashboard, files, tasks
 
 # Create database tables
 Base.metadata.create_all(bind=engine)
@@ -17,3 +17,4 @@ if frontend_path.exists():
 app.include_router(auth.router)
 app.include_router(dashboard.router)
 app.include_router(files.router)
+app.include_router(tasks.router)

--- a/ore_webapp/backend/app/models.py
+++ b/ore_webapp/backend/app/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, Boolean, LargeBinary
+from sqlalchemy import Column, Integer, String, Boolean, LargeBinary, ForeignKey, Date, DateTime
 from sqlalchemy.orm import relationship
+from datetime import datetime
 
 from .database import Base
 
@@ -20,3 +21,21 @@ class StoredFile(Base):
     data = Column(LargeBinary)
     owner_id = Column(Integer)
     owner = relationship("User", back_populates="files")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    description = Column(String, default="")
+    phase = Column(String, index=True)
+    urgency = Column(String, index=True)
+    location = Column(String, index=True)
+    status = Column(String, default="todo", index=True)
+    responsible_id = Column(Integer, ForeignKey("users.id"))
+    due_date = Column(Date, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    responsible = relationship("User")

--- a/ore_webapp/backend/app/routers/__init__.py
+++ b/ore_webapp/backend/app/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import auth, dashboard, files
+from . import auth, dashboard, files, tasks
 
-__all__ = ["auth", "dashboard", "files"]
+__all__ = ["auth", "dashboard", "files", "tasks"]

--- a/ore_webapp/backend/app/routers/tasks.py
+++ b/ore_webapp/backend/app/routers/tasks.py
@@ -1,0 +1,107 @@
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import Task, User
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.post("/")
+def create_task(title: str,
+                description: str = "",
+                phase: str = "",
+                urgency: str = "",
+                location: str = "",
+                responsible_id: Optional[int] = None,
+                due_date: Optional[date] = None,
+                db: Session = Depends(get_db)):
+    task = Task(
+        title=title,
+        description=description,
+        phase=phase,
+        urgency=urgency,
+        location=location,
+        responsible_id=responsible_id,
+        due_date=due_date,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return {"msg": "task created", "id": task.id}
+
+
+@router.get("/")
+def list_tasks(db: Session = Depends(get_db)):
+    tasks = db.query(Task).all()
+    return [
+        {
+            "id": t.id,
+            "title": t.title,
+            "status": t.status,
+            "phase": t.phase,
+            "urgency": t.urgency,
+            "location": t.location,
+            "responsible_id": t.responsible_id,
+            "due_date": t.due_date,
+        }
+        for t in tasks
+    ]
+
+
+@router.put("/{task_id}")
+def update_task(task_id: int,
+                title: Optional[str] = None,
+                description: Optional[str] = None,
+                phase: Optional[str] = None,
+                urgency: Optional[str] = None,
+                location: Optional[str] = None,
+                status: Optional[str] = None,
+                responsible_id: Optional[int] = None,
+                due_date: Optional[date] = None,
+                db: Session = Depends(get_db)):
+    task = db.query(Task).filter(Task.id == task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if title is not None:
+        task.title = title
+    if description is not None:
+        task.description = description
+    if phase is not None:
+        task.phase = phase
+    if urgency is not None:
+        task.urgency = urgency
+    if location is not None:
+        task.location = location
+    if status is not None:
+        task.status = status
+    if responsible_id is not None:
+        task.responsible_id = responsible_id
+    if due_date is not None:
+        task.due_date = due_date
+    db.commit()
+    db.refresh(task)
+    return {"msg": "task updated"}
+
+
+@router.get("/reports/{period}")
+def task_report(period: str, db: Session = Depends(get_db)):
+    if period not in {"daily", "weekly"}:
+        raise HTTPException(status_code=400, detail="Invalid period")
+    now = datetime.utcnow().date()
+    if period == "daily":
+        start = now
+    else:  # weekly
+        start = now - timedelta(days=7)
+    tasks = db.query(Task).filter(Task.updated_at >= start).all()
+    summary = {
+        "total": len(tasks),
+        "by_status": {},
+    }
+    for t in tasks:
+        summary["by_status"].setdefault(t.status, 0)
+        summary["by_status"][t.status] += 1
+    return summary

--- a/ore_webapp/frontend/dashboard.html
+++ b/ore_webapp/frontend/dashboard.html
@@ -7,6 +7,7 @@
 <body>
   <h1>Mission Dashboard</h1>
   <div id="stats"></div>
+  <p><a href="/tasks.html">Task Board</a></p>
   <script>
     async function loadStats() {
       const res = await fetch('/dashboard/');

--- a/ore_webapp/frontend/tasks.html
+++ b/ore_webapp/frontend/tasks.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>ORE Tasks</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <h1>Mission Tasks</h1>
+  <form id="task-form">
+    <input type="text" name="title" placeholder="Title" required />
+    <input type="text" name="description" placeholder="Description" />
+    <input type="text" name="phase" placeholder="Mission Phase" />
+    <input type="text" name="urgency" placeholder="Urgency" />
+    <input type="text" name="location" placeholder="Location" />
+    <input type="number" name="responsible_id" placeholder="Responsible User ID" />
+    <button type="submit">Create Task</button>
+  </form>
+  <h2>Existing Tasks</h2>
+  <div id="tasks"></div>
+  <script>
+    async function loadTasks() {
+      const res = await fetch('/tasks/');
+      if(res.ok) {
+        const data = await res.json();
+        const div = document.getElementById('tasks');
+        div.innerHTML = data.map(t => `<div>[${t.status}] ${t.title} (${t.phase})</div>`).join('');
+      }
+    }
+    loadTasks();
+    const form = document.getElementById('task-form');
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const data = new FormData(form);
+      const res = await fetch('/tasks/', { method: 'POST', body: data });
+      if(res.ok) {
+        form.reset();
+        loadTasks();
+      } else { alert('Error creating task'); }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Task` model for mission tasks
- create `/tasks` API endpoints with daily and weekly reports
- expose task board link in dashboard
- add simple frontend form to create and view tasks
- document new mission task board features

## Testing
- `find . -name '*.py' | xargs python3 -m py_compile`
- `uvicorn app.main:app --port 8000 --reload` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840a03894748322a92582b30ff40aa0